### PR TITLE
upgraded certifi to 2022-12.07

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 Babel==2.10.3
-certifi==2022.9.24
+certifi==2022.12.07
 charset-normalizer==2.1.1
 docutils==0.19
 idna==3.4


### PR DESCRIPTION
Based on a warning email from GitHub dependabot, I modified requirement-frozen.txt to change certifi from 2022.9.24 to 2022.12.07